### PR TITLE
Fix MATLAB plot file errors and improve speed

### DIFF
--- a/export_data_scripts/plot_data_file.m
+++ b/export_data_scripts/plot_data_file.m
@@ -10,6 +10,7 @@ if fid == -1
     error('Unable to open the file');
 end
 
+%% Reading headers and metadata
 % First 4 bytes must be IT02
 first_bytes = fread(fid, 4, 'char')';
 
@@ -44,39 +45,50 @@ if ~isempty(metadata.laser_period_ns)
 end
 
 active_channels = metadata.channels;
-
 number_of_channels = numel(metadata.channels);
-channel_lines = cell(1, number_of_channels);
-
 bin_width_seconds = metadata.bin_width_micros / 1e6;
-times = [];
 
-while true
-    data = fread(fid, 4 * number_of_channels + 8, 'uint8=>uint8');
+%% Main data processing
+% Parameters
+bytes_per_sample = 4 * number_of_channels + 8;
 
-    if isempty(data)
-        break;
-    end
+% Determine how much data remains
+current_pos = ftell(fid);
+fseek(fid, 0, 'eof');
+end_pos = ftell(fid);
+fseek(fid, current_pos, 'bof');
+bytes_remaining = end_pos - current_pos;
 
-    time = typecast(data(1:8), 'double');
-    channel_values = typecast(data(9:end), 'uint32');
+% Number of complete samples
+num_samples = floor(bytes_remaining / bytes_per_sample);
+total_bytes = num_samples * bytes_per_sample;
 
-    for i = 1:numel(channel_lines)
-        channel_lines{i} = [channel_lines{i}, channel_values(i)];
-    end
+% Read all remaining data
+raw_data = fread(fid, total_bytes, 'uint8=>uint8');
 
-    times = [times, time / 1e9];
+% Reshape into [bytes_per_sample x num_samples]
+raw_data = reshape(raw_data, bytes_per_sample, num_samples);
 
-end
+% Parse time (first 8 bytes of each sample)
+time_bytes = raw_data(1:8, :);
+time_vals = typecast(reshape(time_bytes, [], 1), 'double');
+times = time_vals.' / 1e9;
+
+% Parse channel values (remaining bytes of each sample)
+channel_bytes = raw_data(9:end, :);
+channel_vals = typecast(reshape(channel_bytes, [], 1), 'uint32');
+channel_vals = reshape(channel_vals, number_of_channels, num_samples);
 
 fclose(fid);
-
+clear bytes_per_sample bytes_remaining channel_bytes current_pos end_pos...
+    time_bytes time_vals raw_data total_bytes num_samples;
+%% Plotting
 figure;
 hold on;
 
 % Plot data
 for i = 1:numel(active_channels)
-    plot(times, channel_lines{i}, 'LineWidth', 0.5, 'DisplayName', ['Channel ' num2str(active_channels(i) + 1)]);
+    plot(times, channel_vals(i, :), 'LineWidth', 0.5, 'DisplayName', ['Channel ' num2str(active_channels(i) + 1)]);
 end
 
 % Set plot title with metadata information

--- a/export_data_scripts/plot_data_file.m
+++ b/export_data_scripts/plot_data_file.m
@@ -1,4 +1,4 @@
-file_path = '<FILE-PATH>';
+file_path = "<FILE-PATH>";
 
 % Open the file  
 metadata = struct('channels', [], 'bin_width_micros', [], 'acquisition_time_millis', [], 'laser_period_ns', []);
@@ -80,8 +80,8 @@ for i = 1:numel(active_channels)
 end
 
 % Set plot title with metadata information
-title_str = sprintf('Bin Width: %s us, Laser Period: %s ns',
-    num2str(metadata.bin_width_micros),
+title_str = sprintf('Bin Width: %s us, Laser Period: %s ns',...
+    num2str(metadata.bin_width_micros),...
     num2str(metadata.laser_period_ns));
 
 if ~isempty(metadata.acquisition_time_millis)


### PR DESCRIPTION
Fixes errors in MATLAB plotting code due to lack of line continuation. Also makes file_path a string instead of char array to allow for potential file paths with single quotes.